### PR TITLE
Recommend kiwi-systemdeps-containers

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -296,8 +296,12 @@ Group:          %{sysgroup}
 Requires:       kiwi-systemdeps-core = %{version}-%{release}
 Requires:       kiwi-systemdeps-bootloaders = %{version}-%{release}
 %if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version}
+%if 0%{?sle_version} >= 150000 && !0%{?is_opensuse} 
+Recommends:     kiwi-systemdeps-containers
+%else
 # None of the container build tools are available in Debian/Ubuntu
 Requires:       kiwi-systemdeps-containers = %{version}-%{release}
+%endif
 %endif
 Requires:       kiwi-systemdeps-filesystems = %{version}-%{release}
 Requires:       kiwi-systemdeps-disk-images = %{version}-%{release}


### PR DESCRIPTION
This commit recommends kiwi-systemdeps-containers instead of a hard
requirement in kiwi-systemdeps package for SLE builds. This is needed
because the containers tool chain is spread in different SLE modules.