### PR TITLE
Don't exit the script on deprecated function use (bsc#1196644)

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -847,7 +847,6 @@ function deprecated {
         cat
         echo "]"
     } >&2
-    exit 0
 }
 
 


### PR DESCRIPTION
The "exit 0" there stops processing of the calling script with a success exit
code, which leads to incomplete and broken images.