### PR TITLE
Allow install disk overwrite from cmdline

### DIFF
--- a/doc/source/concept_and_workflow/customize_the_boot_process.rst
+++ b/doc/source/concept_and_workflow/customize_the_boot_process.rst
@@ -189,6 +189,19 @@ the available kernel boot parameters for this modules:
   OS deployment is `/dev/sdj`. With `rd.kiwi.oem.maxdisk=500G` the
   deployment will land on that RAID disk.
 
+``rd.kiwi.oem.installdevice``
+  Configures the disk device that should be used in an OEM
+  installation. This overwrites/resets any other oem device specific
+  settings, e.g oem-device-filter, oem-unattended-id or rd.kiwi.oem.maxdisk
+  from the cmdline and just continues the installation on the given
+  device. However, the device must exist and must be a block special.
+
+.. note:: Non interactive mode activated by rd.kiwi.oem.installdevice
+
+   When setting rd.kiwi.oem.installdevice explicitly on the
+   kernel commandline, {kiwi} will not ask for confirmation
+   of the device and just use it !
+
 ``rd.live.overlay.size``
   Tells a live ISO image the size for the `tmpfs` filesystem that is used
   for the `overlayfs` mount process. If the write area of the overlayfs

--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -129,19 +129,6 @@ function get_disk_list {
         )
         device_size=$(echo "${device_meta}" | cut -f2 -d:)
         list_items="${device} ${device_size}"
-        # activate unattended mode. In case a user explicitly
-        # provides the device name to deploy the image to via
-        # the kernel commandline, no further questions if this
-        # is wanted should appear
-        message="rd.kiwi.oem.installdevice set via cmdline to: ${device}"
-        message="${message} The following OEM device settings will be ignored:"
-        message="${message} oem-unattended,"
-        message="${message} oem-unattended-id,"
-        message="${message} oem-device-filter"
-        export kiwi_oemunattended="true"
-        export kiwi_oemunattended_id=""
-        export kiwi_oemdevicefilter=""
-        info "${message}" >&2
     fi
     if [ -z "${list_items}" ];then
         local no_device_text="No device(s) for installation found"

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -174,10 +174,29 @@ function initialize {
     # The method will exit from the initrd if the profile
     # file does not exist
     # """
+    local kiwi_oem_installdevice
     local profile=/.profile
 
     test -f ${profile} || \
         report_and_quit "No profile setup found"
 
     import_file ${profile}
+
+    # Handle overwrites
+    kiwi_oem_installdevice=$(getarg rd.kiwi.oem.installdevice=)
+    if [ -n "${kiwi_oem_installdevice}" ];then
+        # activate unattended mode. In case a user explicitly
+        # provides the device name to deploy the image to via
+        # the kernel commandline, no further questions if this
+        # is wanted should appear
+        message="rd.kiwi.oem.installdevice explicitly set via cmdline."
+        message="${message} The following OEM device settings will be ignored:"
+        message="${message} oem-unattended,"
+        message="${message} oem-unattended-id,"
+        message="${message} oem-device-filter"
+        export kiwi_oemunattended="true"
+        export kiwi_oemunattended_id=""
+        export kiwi_oemdevicefilter=""
+        info "${message}" >&2
+    fi
 }


### PR DESCRIPTION
Add ```rd.kiwi.oem.installdevice=DEVICE```. Configures the disk device that should be used in an OEM installation. This overwrites any other oem device setting, e.g device filter or maxdisk and just continues the installation on the given device. However, the device must exist and must be a block special.

This Fixes jira#PED-7180