### PR TITLE
Live ISO Wait for udev events after repart

### DIFF
--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -66,6 +66,15 @@ function loadKernelModules {
     modprobe squashfs
 }
 
+function udev_pending {
+    declare DEVICE_TIMEOUT=${DEVICE_TIMEOUT}
+    local limit=120
+    if [[ "${DEVICE_TIMEOUT}" =~ ^[0-9]+$ ]]; then
+        limit="${DEVICE_TIMEOUT}"
+    fi
+    udevadm settle --timeout="${limit}"
+}
+
 function initGlobalDevices {
     if [ -z "$1" ]; then
         die "No root device for operation given"
@@ -215,6 +224,7 @@ function preparePersistentOverlayDiskBoot {
                 return 1
             fi
         fi
+        udev_pending
         if [ "$(_partition_count)" -le "${partitions_before_cow_part}" ];then
             return 1
         fi


### PR DESCRIPTION
Make sure to wait for the event queue to become empty after the creation of the write partition. When kiwi calls the code to create the write partition this emits new udev events. It's important to wait for the event queue to become empty to avoid a potential regression on the use of the device nodes. In the processing of the events it can happen that a device gets removed and re-added. If we don't want for udev to process the entire queue it can happen that the wrong block device is used. This wrong selection is only possible because the way how hybrid ISOs are designed exposes both, the disk and the partition for the root device with the same label. This Fixes bsc#1213595