### PR TITLE
Use rsync defaults to sync the initrd root-tree

### DIFF
--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -162,7 +162,7 @@ class BootImageKiwi(BootImageBase):
                 temp_boot_root_directory
             )
             data.sync_data(
-                options=['-a']
+                options=Defaults.get_sync_options()
             )
             boot_directory = temp_boot_root_directory + '/boot'
             Path.wipe(boot_directory)

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -137,7 +137,7 @@ class TestBootImageKiwi:
         mock_os_chmod.assert_called_once_with(
             'temp-boot-directory', 0o755
         )
-        data.sync_data.assert_called_once_with(options=['-a'])
+        data.sync_data.assert_called_once_with(options=['--archive', '--hard-links', '--xattrs', '--acls', '--one-file-system', '--inplace'])
         mock_cpio.assert_called_once_with(
             ''.join(
                 [


### PR DESCRIPTION
This commits makes use of rsync default options to sync the root-tree of the boot image for custom initrds.

Fixes bsc#1207128 and bsc#1221915 where it was noted hardlinks were not preserved inside the initrd.

Signed-off-by: David Cassany <dcassany@suse.com>
(cherry picked from commit ab4abf97dade534e51b32ad04b7202f649e40c4b)