### PR TITLE
Move to py311

### DIFF
--- a/.github/workflows/ci-code-style.yml
+++ b/.github/workflows/ci-code-style.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   unit_tests:
     name: Linter checks for KIWI python and Shell code
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-units-types.yml
+++ b/.github/workflows/ci-units-types.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   unit_tests:
     name: Unit and Static Type tests for KIWI python code
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -26,4 +26,4 @@ jobs:
           python -m pip install tox
       - name: Run unit and type tests
         run: |
-          tox -e unit_py3_6,unit_py3_8,unit_py3_9,unit_py3_10
+          tox -e unit_py3_11

--- a/kiwi/utils/sync.py
+++ b/kiwi/utils/sync.py
@@ -16,10 +16,10 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import errno
 import logging
 from stat import ST_MODE
 from typing import List
-import xattr
 
 # project
 from kiwi.command import Command
@@ -134,9 +134,11 @@ class DataSync:
         :rtype: bool
         """
         try:
-            xattr.getxattr(self.target_dir, 'user.mime_type')
-        except Exception as e:
-            if format(e).startswith('[Errno 95]'):
-                # libc interface [Errno 95] Operation not supported:
+            os.getxattr(self.target_dir, 'user.mime_type')
+        except OSError as e:
+            log.debug(
+                f'Check for extended attributes on {self.target_dir} said: {e}'
+            )
+            if e.errno == errno.ENOTSUP:
                 return False
         return True

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -1,7 +1,7 @@
 #
 # spec file for package kiwi
 #
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,31 +17,7 @@
 #       https://github.com/OSInside/kiwi/issues
 #
 
-# If they aren't provided by a system installed macro, define them
-%{!?_defaultdocdir: %global _defaultdocdir %{_datadir}/doc}
-%{!?__python3: %global __python3 /usr/bin/python3}
-
-%if %{undefined python3_sitelib}
-%global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
-%endif
-
-%if 0%{?el7}
-%global python3_pkgversion 36
-%else
-%{!?python3_pkgversion:%global python3_pkgversion 3}
-%endif
-
-%if 0%{?debian} || 0%{?ubuntu}
-%global is_deb 1
-%global pygroup python
-%global sysgroup admin
-%global develsuffix dev
-%else
-%global pygroup Development/Languages/Python
-%global sysgroup System/Management
-%global develsuffix devel
-%endif
-
+%{?sle15_python_module_pythons}
 Name:           python-kiwi
 Version:        %%VERSION
 Provides:       kiwi-schema = 7.5
@@ -49,26 +25,30 @@ Release:        0
 Url:            https://github.com/OSInside/kiwi
 Summary:        KIWI - Appliance Builder Next Generation
 License:        GPL-3.0-or-later
-%if "%{_vendor}" == "debbuild"
-# Needed to set Maintainer in output debs
-Packager:       Marcus Schaefer <ms@suse.de>
-%endif
 Group:          %{pygroup}
 Source:         %{name}.tar.gz
 Source1:        %{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  gcc
-BuildRequires:  python%{python3_pkgversion}-%{develsuffix} >= 3.6
-BuildRequires:  python%{python3_pkgversion}-setuptools
-%if 0%{?fedora} || 0%{?suse_version}
 BuildRequires:  fdupes
-%endif
-%if 0%{?suse_version}
 BuildRequires:  shadow
-%endif
-%if 0%{?debian} || 0%{?ubuntu}
-BuildRequires:  passwd
-%endif
+BuildRequires:  python3
+BuildRequires:  %{python_module PyYAML}
+BuildRequires:  %{python_module simplejson}
+BuildRequires:  %{python_module docopt}
+BuildRequires:  %{python_module lxml}
+BuildRequires:  %{python_module requests}
+BuildRequires:  %{python_module setuptools}
+Requires:       python-PyYAML
+Requires:       python-simplejson
+Requires:       python-docopt
+Requires:       python-lxml
+Requires:       python-requests
+Requires:       python-setuptools
+Requires:       screen
+# Only require core dependencies, and allow OBS to pull the rest through magic Provides
+Requires:       kiwi-systemdeps-core = %{version}-%{release}
+%python_subpackages
 
 %description
 The KIWI Image System provides an operating system image builder
@@ -333,50 +313,6 @@ Requires:       kiwi-systemdeps-image-validation = %{version}-%{release}
 Host setup helper to pull in all packages required/useful to
 leverage all functionality in KIWI.
 
-# python3-kiwi
-%package -n python%{python3_pkgversion}-kiwi
-Summary:        KIWI - Appliance Builder Next Generation
-Group:          %{pygroup}
-Obsoletes:      python2-kiwi
-Conflicts:      python2-kiwi
-Conflicts:      kiwi-man-pages < %{version}
-Requires:       screen
-Requires:       python%{python3_pkgversion} >= 3.6
-%if 0%{?ubuntu} || 0%{?debian}
-Requires:       python%{python3_pkgversion}-yaml
-%else
-Requires:       python%{python3_pkgversion}-PyYAML
-%endif
-Requires:       python%{python3_pkgversion}-simplejson
-Requires:       python%{python3_pkgversion}-docopt
-Requires:       python%{python3_pkgversion}-lxml
-Requires:       python%{python3_pkgversion}-requests
-Requires:       python%{python3_pkgversion}-setuptools
-%if (0%{?suse_version} && 0%{?suse_version} < 1550)
-Requires:       python%{python3_pkgversion}-xattr
-%else
-Requires:       python%{python3_pkgversion}-pyxattr
-%endif
-%if ! (0%{?rhel} && 0%{?rhel} < 8)
-Recommends:     kiwi-man-pages
-%endif
-%if "%{_vendor}" == "debbuild"
-# Avoid issues with not being able to use magic Provides
-Requires:       kiwi-systemdeps = %{version}-%{release}
-%else
-# Only require core dependencies, and allow OBS to pull the rest through magic Provides
-Requires:       kiwi-systemdeps-core = %{version}-%{release}
-%if ! 0%{?el7}
-# Retain default expectation for local installations
-Recommends:     kiwi-systemdeps = %{version}-%{release}
-%endif
-%endif
-
-%description -n python%{python3_pkgversion}-kiwi
-Python 3 library of the KIWI Image System. Provides an operating system
-image builder for Linux supported hardware platforms as well as for
-virtualization and cloud systems like Xen, KVM, VMware, EC2 and more.
-
 %package -n kiwi-tools
 Summary:        KIWI - Collection of Boot Helper Tools
 License:        GPL-3.0-or-later
@@ -578,18 +514,14 @@ Provides manual pages to describe the kiwi commands
 # as an independent script
 sed -e "s|#!/usr/bin/env python||" -i kiwi/xml_parse.py
 
-%if 0%{?suse_version} && 0%{?suse_version} < 1550
-# For older SUSE distributions, use the other xattr Python module
-sed -e "s|pyxattr|xattr|" -i setup.py
-%endif
-
 %build
 # Build C-Tools
 make CFLAGS="${RPM_OPT_FLAGS}" tools
+%python_build
 
 %install
-# Install Python 3 version
-python3 setup.py install --prefix=%{_prefix} --root=%{buildroot} %{?is_deb:--install-layout=deb}
+%python_install
+%python_expand %fdupes %{buildroot}%{$python_sitelib}
 
 # Install C-Tools, man-pages, completion and kiwi default configuration
 make buildroot=%{buildroot}/ install
@@ -657,14 +589,14 @@ fi
 %files -n kiwi-systemdeps
 # Empty metapackage
 
-%files -n python%{python3_pkgversion}-kiwi
+%files %{python_files}
 %dir %{_defaultdocdir}/python-kiwi
 %{_bindir}/kiwi
 %{_bindir}/kiwi-ng
 %{_bindir}/kiwicompat
 %{_bindir}/kiwi-ng-3*
 %{_bindir}/kiwicompat-3*
-%{python3_sitelib}/kiwi*
+%{python_sitelib}/*
 %{_usr}/share/bash-completion/completions/kiwi-ng
 %{_defaultdocdir}/python-kiwi/LICENSE
 %{_defaultdocdir}/python-kiwi/README

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -282,7 +282,7 @@ Group:          %{sysgroup}
 Recommends:     jing
 %endif
 %if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version}
-Requires:       python%{python3_pkgversion}-solv
+Recommends:     python%{python3_pkgversion}-solv
 %endif
 %if ! (0%{?rhel} && 0%{?rhel} < 8)
 Recommends:     python%{python3_pkgversion}-anymarkup

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -21,6 +21,11 @@
 Name:           python-kiwi
 Version:        %%VERSION
 Provides:       kiwi-schema = 7.5
+Obsoletes:      python2-kiwi
+Conflicts:      python2-kiwi
+Obsoletes:      python3-kiwi
+Conflicts:      python3-kiwi
+Conflicts:      kiwi-man-pages < %{version}
 Release:        0
 Url:            https://github.com/OSInside/kiwi
 Summary:        KIWI - Appliance Builder Next Generation

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ config = {
     'install_requires': [
         'docopt>=0.6.2',
         'lxml',
-        'pyxattr',
         'requests',
         'PyYAML',
         'simplejson'

--- a/test/unit/utils/sync_test.py
+++ b/test/unit/utils/sync_test.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import errno
 from pytest import fixture
 from stat import ST_MODE
 from mock import patch
@@ -57,16 +58,16 @@ class TestDataSync:
             ['rsync', 'source_dir/', 'target_dir']
         )
 
-    @patch('xattr.getxattr')
+    @patch('os.getxattr')
     def test_target_supports_extended_attributes(self, mock_getxattr):
         assert self.sync.target_supports_extended_attributes() is True
         mock_getxattr.assert_called_once_with(
             'target_dir', 'user.mime_type'
         )
 
-    @patch('xattr.getxattr')
+    @patch('os.getxattr')
     def test_target_does_not_support_extended_attributes(self, mock_getxattr):
-        mock_getxattr.side_effect = OSError(
-            """[Errno 95] Operation not supported: b'/boot/efi"""
-        )
+        effect = OSError()
+        effect.errno = errno.ENOTSUP
+        mock_getxattr.side_effect = effect
         assert self.sync.target_supports_extended_attributes() is False


### PR DESCRIPTION
Move to python 3.11 stack for SLE/Leap
    
Since SLE and Leap has python 3.11 we can now finally move to
a newer python version for this target
