### PR TITLE
Add rd.kiwi.oem.force_resize boot option

### DIFF
--- a/doc/source/concept_and_workflow/customize_the_boot_process.rst
+++ b/doc/source/concept_and_workflow/customize_the_boot_process.rst
@@ -189,6 +189,20 @@ the available kernel boot parameters for this modules:
   OS deployment is `/dev/sdj`. With `rd.kiwi.oem.maxdisk=500G` the
   deployment will land on that RAID disk.
 
+``rd.kiwi.oem.force_resize``
+  Forces the disk resize process on an OEM disk image. If set, no sanity
+  check for unpartitioned/free space is performed and also an eventually
+  configured `<oem-resize-once>` configuration from the image description
+  will not be taken into account. The disk resize will be started which
+  includes re-partition as well as all steps to resize the block layers
+  up to the filesystem holding the data. As `rd.kiwi.oem.force_resize`
+  bypasses all sanity checks to detect if such a resize process is
+  needed or not, it can happen that all program calls of the resize
+  process ends without any effect if the disk is already properly
+  resized. It's also important to understand that the partition UUIDs
+  will change on every resize which might be an unwanted side effect
+  of a forced resize.
+
 ``rd.kiwi.oem.installdevice``
   Configures the disk device that should be used in an OEM
   installation. This overwrites/resets any other oem device specific

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -402,6 +402,11 @@ function resize_wanted {
     local root_device=$1
     local disk_device=$2
     kiwi_oemresizeonce=$(bool "${kiwi_oemresizeonce}")
+    if getargbool 0 rd.kiwi.oem.force_resize; then
+        info "System resize forced via rd.kiwi.oem.force_resize"
+        info "Activating resize operation"
+        return 0
+    fi
     if [ "${kiwi_oemresizeonce}" = "true" ];then
         current_rootpart_uuid=$(get_partition_uuid "${root_device}")
         if [ "${current_rootpart_uuid}" == "${kiwi_rootpartuuid}" ];then


### PR DESCRIPTION
Forces the disk resize process on an OEM disk image. If set, no sanity check for unpartitioned/free
space is performed and also an eventually configured `<oem-resize-once>` configuration from the image description will not
be taken into account. This Fixes bsc#1224389