### PR TITLE
Fix kiwi-repart restrictions

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -16,11 +16,12 @@ function initialize {
     local partition_ids=/config.partids
 
     test -f ${profile} || \
-        die "No profile setup found"
+        warn "No profile setup found"
+        warn "Settings from the kiwi description will be ignored"
     test -f ${partition_ids} || \
         die "No partition id setup found"
 
-    import_file ${profile}
+    test -f ${profile} && import_file ${profile}
     import_file ${partition_ids}
 
     disk=$(lookup_disk_device_from_root)

--- a/dracut/modules.d/90kiwi-repart/module-setup.sh
+++ b/dracut/modules.d/90kiwi-repart/module-setup.sh
@@ -19,6 +19,11 @@ installkernel() {
 # called by dracut
 install() {
     declare moddir=${moddir}
-    inst_hook pre-mount 20 "${moddir}/kiwi-repart-disk.sh"
-    dracut_need_initqueue
+    if inst_simple /config.partids; then
+        test -f /.profile && inst_simple /.profile
+        inst_hook pre-mount 20 "${moddir}/kiwi-repart-disk.sh"
+        dracut_need_initqueue
+    else
+        echo "ERROR: kiwi-repart needs /config.partids; not installing module"
+    fi
 }


### PR DESCRIPTION
The kiwi repart dracut module reads a profile file and if it does not exists it dies in the initrd. However, that profile file is not mandatory for the main resize functionality. Thus this commit turns this into a warning message. In addition the module-setup for 90kiwi-repart makes sure to include the required and optional profile files.
This Fixes bsc#1228118