### PR TITLE
Fixed regression in GRUB_SERIAL_COMMAND setup

### DIFF
--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -27,7 +27,6 @@ wheel
 # Python style guide checker
 flake8
 mypy
-types-pkg_resources
 types-requests
 types-PyYAML
 types-mock

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -731,7 +731,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 grub_final_cmdline
             )
         if self.serial_line_setup and \
-           'serial' in self.terminal_input or 'serial' in self.terminal_output:
+           ('serial' in self.terminal_input or 'serial' in self.terminal_output):
             grub_default_entries['GRUB_SERIAL_COMMAND'] = '"{0}"'.format(
                 self.serial_line_setup
             )


### PR DESCRIPTION
The condition to write the serial line setup was broken. This commit fixes it. Related to Issue #2419 and
Fixes bsc#1228808