### PR TITLE
Backport ppc64le install iso generation

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -879,7 +879,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             <chrp-boot>
             <description>{os_name}</description>
             <os-name>{os_name}</os-name>
-            <boot-script>boot &device;:1,\boot\grub2\powerpc-ieee1275\grub.elf</boot-script>
+            <boot-script>boot &device;:1,\\boot\\grub2\\powerpc-ieee1275\\grub.elf</boot-script>
             </chrp-boot>
         ''')
         with open(chrp_bootinfo_file, 'w') as chrp_bootinfo:

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 from string import Template
+from textwrap import dedent
 import re
 import os
 import logging
@@ -571,7 +572,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
 
     def _supports_bios_modules(self):
-        if self.arch == 'ix86' or self.arch == 'x86_64':
+        if self.arch == 'ix86' or self.arch == 'x86_64' or Defaults.is_ppc64_arch(self.arch):
             return True
         return False
 
@@ -861,6 +862,30 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 uuid, mbrid, lookup_path
             )
 
+    def _setup_chrp_config(self, mbrid):
+        early_boot_script = os.path.normpath(
+            os.sep.join(
+                [self._get_grub2_boot_path(), 'powerpc-ieee1275', 'grub.cfg']
+            )
+        )
+        self._create_early_boot_script_for_mbrid_search(
+            early_boot_script, mbrid
+        )
+        chrp_dir = os.path.normpath(os.sep.join([self.boot_dir, 'ppc']))
+        Path.create(chrp_dir)
+        chrp_bootinfo_file = os.sep.join([chrp_dir, 'bootinfo.txt'])
+        chrp_config = dedent('''
+            <chrp-boot>
+            <description>{os_name}</description>
+            <os-name>{os_name}</os-name>
+            <boot-script>boot &device;:1,\boot\grub2\powerpc-ieee1275\grub.elf</boot-script>
+            </chrp-boot>
+        ''')
+        with open(chrp_bootinfo_file, 'w') as chrp_bootinfo:
+            chrp_bootinfo.write(
+                chrp_config.format(os_name=self.get_menu_entry_install_title())
+            )
+
     def _setup_bios_image(self, mbrid=None, lookup_path=None):
         """
         Provide bios grub image
@@ -875,6 +900,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             self._create_bios_image(
                 mbrid, lookup_path
             )
+        if Defaults.is_ppc64_arch(Defaults.get_platform_name()):
+            self._setup_chrp_config(mbrid)
+            return
         bash_command = ' '.join(
             [
                 'cat',
@@ -1138,7 +1166,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         )
 
     def _get_bios_modules_path(self, lookup_path=None):
-        return self._get_module_path('i386-pc', lookup_path)
+        return self._get_module_path(Defaults.get_bios_module_directory_name(), lookup_path)
 
     def _get_xen_modules_path(self, lookup_path=None):
         return self._get_module_path(

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -450,7 +450,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         :param string lookup_path: custom module lookup path
         """
         log.info('Creating grub2 bootloader images')
-        self.efi_boot_path = self.create_efi_path(in_sub_dir='')
+        if self.firmware.efi_mode():
+            self.efi_boot_path = self.create_efi_path(in_sub_dir='')
 
         log.info('--> Creating identifier file %s', mbrid.get_id())
         grub_boot_path = self._get_grub2_boot_path()

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -881,7 +881,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             <os-name>{os_name}</os-name>
             <boot-script>boot &device;:1,\\boot\\grub2\\powerpc-ieee1275\\grub.elf</boot-script>
             </chrp-boot>
-        ''')
+        ''').strip() + os.linesep
         with open(chrp_bootinfo_file, 'w') as chrp_bootinfo:
             chrp_bootinfo.write(
                 chrp_config.format(os_name=self.get_menu_entry_install_title())

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -204,7 +204,7 @@ class InstallImageBuilder:
         log.info(
             'Setting up install image bootloader configuration'
         )
-        if self.firmware.efi_mode():
+        if self.firmware.efi_mode() or self.firmware.ofw_mode():
             # setup bootloader config to boot the ISO via EFI
             # This also embedds an MBR and the respective BIOS modules
             # for compat boot. The complete bootloader setup will be

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -197,6 +197,24 @@ class Defaults:
         return False
 
     @staticmethod
+    def is_ppc64_arch(arch):
+        """
+        Checks if machine architecture is ppc64 based
+
+        Any arch that matches little endian or big endian ppc64 architecture
+        causes the method to return True. Anything else will
+        cause the method to return False
+
+        :rtype: bool
+        """
+        ppc64_arch_names = [
+            'ppc64', 'ppc64le'
+        ]
+        if arch in ppc64_arch_names:
+            return True
+        return False
+
+    @staticmethod
     def is_buildservice_worker():
         """
         Checks if build host is an open buildservice machine
@@ -879,11 +897,11 @@ class Defaults:
         :rtype: str
         """
         bios_grub_core_patterns = [
-            '/usr/share/grub*/i386-pc/{0}'.format(
-                Defaults.get_bios_image_name()
+            '/usr/share/grub*/{0}/{1}'.format(
+                Defaults.get_bios_module_directory_name(), Defaults.get_bios_image_name()
             ),
-            '/usr/lib/grub*/i386-pc/{0}'.format(
-                Defaults.get_bios_image_name()
+            '/usr/lib/grub*/{0}/{1}'.format(
+                Defaults.get_bios_module_directory_name(), Defaults.get_bios_image_name()
             )
         ]
         for bios_grub_core_pattern in bios_grub_core_patterns:
@@ -1298,13 +1316,13 @@ class Defaults:
     @staticmethod
     def get_bios_module_directory_name():
         """
-        Provides x86 BIOS directory name which stores the pc binaries
+        Provides BIOS directory name which stores the pc binaries
 
         :return: directory name
 
         :rtype: str
         """
-        return 'i386-pc'
+        return 'powerpc-ieee1275' if Defaults.is_ppc64_arch(Defaults.get_platform_name()) else 'i386-pc'
 
     @staticmethod
     def get_efi_image_name(arch):
@@ -1340,7 +1358,7 @@ class Defaults:
 
         :rtype: str
         """
-        return 'core.img'
+        return 'grub.elf' if Defaults.is_ppc64_arch(Defaults.get_platform_name()) else 'core.img'
 
     @staticmethod
     def get_default_boot_timeout_seconds():

--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -94,6 +94,10 @@ class IsoToolsXorrIso(IsoToolsBase):
         self.iso_parameters += [
             '-joliet', 'on', '-padding', '0'
         ]
+        if Defaults.is_ppc64_arch(self.arch):
+            self.iso_parameters += [
+                '-compliance', 'untranslated_names'
+            ]
 
         if Defaults.is_x86_arch(self.arch):
             if efi_mode:
@@ -126,15 +130,20 @@ class IsoToolsXorrIso(IsoToolsBase):
                     '-boot_image', 'isolinux', 'partition_table=on',
                 ]
 
-        self.iso_loaders += [
-            '-boot_image', 'any', 'partition_offset=16',
-            '-boot_image', 'any', 'cat_path={0}'.format(catalog_file),
-            '-boot_image', 'any', 'cat_hidden=on',
-            '-boot_image', 'any', 'boot_info_table=on',
-            '-boot_image', 'any', 'platform_id=0x00',
-            '-boot_image', 'any', 'emul_type=no_emulation',
-            '-boot_image', 'any', 'load_size=2048'
-        ]
+        if Defaults.is_ppc64_arch(self.arch):
+            self.iso_loaders += [
+                '-boot_image', 'any', 'chrp_boot_part=on'
+            ]
+        else:
+            self.iso_loaders += [
+                '-boot_image', 'any', 'partition_offset=16',
+                '-boot_image', 'any', 'cat_path={0}'.format(catalog_file),
+                '-boot_image', 'any', 'cat_hidden=on',
+                '-boot_image', 'any', 'boot_info_table=on',
+                '-boot_image', 'any', 'platform_id=0x00',
+                '-boot_image', 'any', 'emul_type=no_emulation',
+                '-boot_image', 'any', 'load_size=2048'
+            ]
 
     def add_efi_loader_parameters(self, loader_file: str) -> None:
         """

--- a/test/data/bootinfo.txt
+++ b/test/data/bootinfo.txt
@@ -1,0 +1,6 @@
+
+<chrp-boot>
+<description>Bob</description>
+<os-name>Bob</os-name>
+<boot-script>boot &device;:1,\boot\grub2\powerpc-ieee1275\grub.elf</boot-script>
+</chrp-boot>

--- a/test/data/bootinfo.txt
+++ b/test/data/bootinfo.txt
@@ -1,4 +1,3 @@
-
 <chrp-boot>
 <description>Bob</description>
 <os-name>Bob</os-name>

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1676,6 +1676,9 @@ class TestBootLoaderConfigGrub2:
 
         mock_exists.side_effect = side_effect
 
+        with open('../data/bootinfo.txt') as chrp:
+            grub2_test_chrp_boot = chrp.read()
+
         with patch('builtins.open', create=True) as mock_open:
             mock_open.return_value = MagicMock(spec=io.IOBase)
             file_handle = mock_open.return_value.__enter__.return_value
@@ -1694,12 +1697,7 @@ class TestBootLoaderConfigGrub2:
                 call('search --file --set=root /boot/0xffffffff\n'),
                 call('set prefix=($root)/boot/grub2\n'),
                 call('source ($root)/boot/grub2/grub.cfg\n'),
-                call(
-                    '\n<chrp-boot>\n<description>Bob</description>\n'
-                    '<os-name>Bob</os-name>\n<boot-script>'
-                    'boot &device;:1,\boot\grub2\powerpc-ieee1275\grub.elf'
-                    '</boot-script>\n</chrp-boot>\n'
-                ),
+                call(grub2_test_chrp_boot),
                 call('source /boot/grub2/grub.cfg\n')
             ]
 

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -1696,7 +1696,7 @@ class TestBootLoaderConfigGrub2:
                 call('set btrfs_relative_path="yes"\n'),
                 call('search --file --set=root /boot/0xffffffff\n'),
                 call('set prefix=($root)/boot/grub2\n'),
-                call('source ($root)/boot/grub2/grub.cfg\n'),
+                call('configfile ($root)/boot/grub2/grub.cfg\n'),
                 call(grub2_test_chrp_boot),
                 call('source /boot/grub2/grub.cfg\n')
             ]

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -60,7 +60,8 @@ class TestBootLoaderConfigGrub2:
             'root_dir/usr/lib64/efi/shim.efi': True,
             'root_dir/usr/lib64/efi/grub.efi': True,
             'root_dir/usr/lib64/efi/does-not-exist': False,
-            'root_dir/boot/efi/': True
+            'root_dir/boot/efi/': True,
+            'root_dir/usr/share/grub2/powerpc-ieee1275': True
         }
         self.glob_iglob = [
             ['root_dir/usr/lib64/efi/MokManager.efi'],
@@ -1636,6 +1637,71 @@ class TestBootLoaderConfigGrub2:
                         ]
                     )
                 ]
+
+    @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_boot_path')
+    @patch('kiwi.bootloader.config.grub2.Defaults.get_unsigned_grub_loader')
+    @patch('kiwi.bootloader.config.grub2.Defaults.get_grub_bios_core_loader')
+    @patch('kiwi.bootloader.config.grub2.Command.run')
+    @patch('kiwi.bootloader.config.grub2.Path.which')
+    @patch('kiwi.bootloader.config.grub2.Path.create')
+    @patch('kiwi.bootloader.config.grub2.DataSync')
+    @patch('os.path.exists')
+    @patch('shutil.copy')
+    def test_setup_install_boot_images_ppc(
+        self, mock_shutil_copy, mock_exists, mock_sync,
+        mock_Path_create, mock_Path_which, mock_command,
+        mock_get_grub_bios_core_loader, mock_get_unsigned_grub_loader,
+        mock_get_boot_path
+    ):
+        Defaults.set_platform_name('ppc64le')
+        mock_Path_which.return_value = '/path/to/grub2-mkimage'
+        mock_get_boot_path.return_value = '/boot'
+        self.bootloader.arch = 'ppc64le'
+        data = Mock()
+        mock_sync.return_value = data
+        self.firmware.efi_mode = Mock(
+            return_value=''
+        )
+
+        # simulate alternative boot directory to reach all code paths
+        self.bootloader.boot_dir = 'boot_dir'
+
+        self.os_exists['lookup_dir/usr/share/grub2/powerpc-ieee1275'] = True
+        self.os_exists['lookup_dir/usr/share/grub2/unicode.pf2'] = True
+        self.os_exists['boot_dir/boot/grub2/fonts/unicode.pf2'] = False
+        self.os_exists['boot_dir/usr/share/grub2/unicode.pf2'] = True
+
+        def side_effect(arg):
+            return self.os_exists[arg]
+
+        mock_exists.side_effect = side_effect
+
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.return_value = MagicMock(spec=io.IOBase)
+            file_handle = mock_open.return_value.__enter__.return_value
+            self.bootloader.setup_install_boot_images(
+                mbrid=self.mbrid, lookup_path="lookup_dir"
+            )
+
+            assert mock_open.call_args_list == [
+                call('boot_dir/boot/grub2/powerpc-ieee1275/grub.cfg', 'w'),
+                call('boot_dir/ppc/bootinfo.txt', 'w'),
+                call('boot_dir/boot/grub2/loopback.cfg', 'w')
+            ]
+
+            assert file_handle.write.call_args_list == [
+                call('set btrfs_relative_path="yes"\n'),
+                call('search --file --set=root /boot/0xffffffff\n'),
+                call('set prefix=($root)/boot/grub2\n'),
+                call('source ($root)/boot/grub2/grub.cfg\n'),
+                call(
+                    '\n<chrp-boot>\n<description>Bob</description>\n'
+                    '<os-name>Bob</os-name>\n<boot-script>'
+                    'boot &device;:1,\boot\grub2\powerpc-ieee1275\grub.elf'
+                    '</boot-script>\n</chrp-boot>\n'
+                ),
+                call('source /boot/grub2/grub.cfg\n')
+            ]
 
     @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_boot_path')
     @patch('kiwi.bootloader.config.grub2.Defaults.get_unsigned_grub_loader')

--- a/test/unit/builder/install_test.py
+++ b/test/unit/builder/install_test.py
@@ -155,6 +155,7 @@ class TestInstallImageBuilder:
         mock_BootLoaderConfig.return_value = bootloader_config
         mock_Temporary.side_effect = side_effect
 
+        self.firmware.ofw_mode.return_value = False
         self.firmware.bios_mode.return_value = False
 
         m_open = mock_open()
@@ -263,6 +264,7 @@ class TestInstallImageBuilder:
         mock_BootLoaderConfig.reset_mock()
         tmp_names = [temp_esp_file, temp_squashfs, temp_media_dir]
         self.firmware.efi_mode.return_value = None
+        self.firmware.ofw_mode.return_value = False
         self.firmware.bios_mode.return_value = True
 
         with patch('builtins.open', m_open, create=True):

--- a/test/unit/iso_tools/xorriso_test.py
+++ b/test/unit/iso_tools/xorriso_test.py
@@ -92,7 +92,6 @@ class TestIsoToolsXorrIso:
             '-compliance', 'untranslated_names'
         ]
 
-    @patch('os.path.exists')
     def test_init_iso_creation_parameters_efi(self):
         self.iso_tool.init_iso_creation_parameters(
             {

--- a/test/unit/iso_tools/xorriso_test.py
+++ b/test/unit/iso_tools/xorriso_test.py
@@ -68,6 +68,31 @@ class TestIsoToolsXorrIso:
             '-boot_image', 'any', 'load_size=2048'
         ]
 
+    @patch('os.path.exists')
+    def test_init_iso_creation_parameters_ppc(self, mock_os_path_exists):
+        mock_os_path_exists.return_value = True
+        self.iso_tool.arch = 'ppc64le'
+        self.iso_tool.init_iso_creation_parameters(
+            {
+                'mbr_id': 'app_id',
+                'publisher': 'org',
+                'preparer': 'preparer',
+                'volume_id': 'vol_id',
+                'efi_mode': 'ofw',
+                'legacy_bios_mode': False
+            }
+        )
+        assert self.iso_tool.iso_parameters == [
+            '-application_id', 'app_id',
+            '-publisher', 'org',
+            '-preparer_id', 'preparer',
+            '-volid', 'vol_id',
+            '-joliet', 'on',
+            '-padding', '0',
+            '-compliance', 'untranslated_names'
+        ]
+
+    @patch('os.path.exists')
     def test_init_iso_creation_parameters_efi(self):
         self.iso_tool.init_iso_creation_parameters(
             {


### PR DESCRIPTION
This set of commits are backports of ppc64le ISO image generation fixes from Kiwi10.

With SUMA5.0 we are based on SLEM5.5, but we also have ppc64le support so we need to have ppc64le self install iso with kiwi9 used by SLEM5.5.

This list also contains one more commit from me which actually enables grub install setup also for OFW firmwares and not only EFI firmwares.