### PR TITLE
Set grub-bls default to false for SUSE on SLES15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,8 @@ build: clean tox
 		-e s"@%%MD5SUM@$${md5sums}@" > dist/PKGBUILD
 	# provide rpm rpmlintrc
 	cp package/python-kiwi-rpmlintrc dist
+	# provide patches
+	cp package/*.patch dist
 
 pypi: clean tox
 	$(python) setup.py sdist upload

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -195,13 +195,8 @@ html_sidebars = {
 
 html_theme = "sphinx_rtd_theme"
 
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
-html_static_path = ['.static']
-
 html_theme_options = {
-    'collapse_navigation': False,
-    'display_version': False
+    'collapse_navigation': False
 }
 
 # -- Options for manual page output ---------------------------------------

--- a/package/kiwi-revert-bls-default-for-suse.patch
+++ b/package/kiwi-revert-bls-default-for-suse.patch
@@ -1,0 +1,56 @@
+diff --git a/kiwi/bootloader/config/grub2.py b/kiwi/bootloader/config/grub2.py
+index 461b168c0..120088d6b 100644
+--- a/kiwi/bootloader/config/grub2.py
++++ b/kiwi/bootloader/config/grub2.py
+@@ -764,15 +764,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
+         if self.custom_args.get('crypto_disk'):
+             grub_default_entries['GRUB_ENABLE_CRYPTODISK'] = 'y'
+ 
+-        enable_blscfg_implemented = Command.run(
+-            [
+-                'grep', '-q', 'GRUB_ENABLE_BLSCFG',
+-                self._get_grub2_mkconfig_tool()
+-            ], raise_on_error=False
+-        )
+-        if enable_blscfg_implemented.returncode == 0:
+-            grub_default_entries['GRUB_ENABLE_BLSCFG'] = 'true'
+-
+         if grub_default_entries:
+             log.info('Writing grub2 defaults file')
+             grub_default_location = ''.join([self.root_dir, '/etc/default/'])
+diff --git a/test/unit/bootloader/config/grub2_test.py b/test/unit/bootloader/config/grub2_test.py
+index 19e0f4d98..daf8e5868 100644
+--- a/test/unit/bootloader/config/grub2_test.py
++++ b/test/unit/bootloader/config/grub2_test.py
+@@ -579,7 +579,6 @@ class TestBootLoaderConfigGrub2:
+             ),
+             call('GRUB_CMDLINE_LINUX_DEFAULT', '"some-cmdline"'),
+             call('GRUB_DISTRIBUTOR', '"Bob"'),
+-            call('GRUB_ENABLE_BLSCFG', 'true'),
+             call('GRUB_ENABLE_CRYPTODISK', 'y'),
+             call('GRUB_GFXMODE', '800x600'),
+             call(
+@@ -625,7 +624,6 @@ class TestBootLoaderConfigGrub2:
+             call('GRUB_CMDLINE_LINUX', '"root=LABEL=some-label"'),
+             call('GRUB_DISABLE_LINUX_UUID', 'true'),
+             call('GRUB_DISTRIBUTOR', '"Bob"'),
+-            call('GRUB_ENABLE_BLSCFG', 'true'),
+             call('GRUB_ENABLE_CRYPTODISK', 'y'),
+             call('GRUB_ENABLE_LINUX_LABEL', 'true'),
+             call('GRUB_GFXMODE', '800x600'),
+@@ -670,7 +668,6 @@ class TestBootLoaderConfigGrub2:
+             call('GRUB_DISABLE_LINUX_PARTUUID', 'false'),
+             call('GRUB_DISABLE_LINUX_UUID', 'true'),
+             call('GRUB_DISTRIBUTOR', '"Bob"'),
+-            call('GRUB_ENABLE_BLSCFG', 'true'),
+             call('GRUB_ENABLE_CRYPTODISK', 'y'),
+             call('GRUB_GFXMODE', '800x600'),
+             call(
+@@ -714,7 +711,6 @@ class TestBootLoaderConfigGrub2:
+             call('GRUB_CMDLINE_LINUX_DEFAULT', '"abcd console=tty0"'),
+             call('GRUB_DISABLE_LINUX_UUID', 'true'),
+             call('GRUB_DISTRIBUTOR', '"Bob"'),
+-            call('GRUB_ENABLE_BLSCFG', 'true'),
+             call('GRUB_ENABLE_CRYPTODISK', 'y'),
+             call('GRUB_ENABLE_LINUX_LABEL', 'true'),
+             call('GRUB_GFXMODE', '800x600'),

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -56,6 +56,9 @@ Packager:       Marcus Schaefer <ms@suse.de>
 Group:          %{pygroup}
 Source:         %{name}.tar.gz
 Source1:        %{name}-rpmlintrc
+# SUSE-specific patches (1001+)
+## PATCH-FIX-OPENSUSE kiwi-revert-bls-default-for-suse.patch -- temporary until opensuse has bls
+Patch1001:      kiwi-revert-bls-default-for-suse.patch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  gcc
 BuildRequires:  python%{python3_pkgversion}-%{develsuffix} >= 3.6
@@ -573,6 +576,11 @@ Provides manual pages to describe the kiwi commands
 
 %prep
 %setup -q -n kiwi-%{version}
+
+%if 0%{?suse_version}
+# Temporarily revert grub-bls default to false for SUSE distributions
+%patch -P 1001 -p1
+%endif
 
 # Drop shebang for kiwi/xml_parse.py, as we don't intend to use it
 # as an independent script


### PR DESCRIPTION
For the time being, SLES15 distributions cannot handle KIWI's default to use BLS with GRUB2. Until they catch up, revert this for them only.