### PR TITLE
Fix file references in kiwi bundler result files

### DIFF
--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -275,6 +275,8 @@ class ResultBundleTask(CliTask):
         image_name = result.xml_state.xml_data.get_name()
         if '.tar.' in result_file.filename:
             extension = f'tar.{result_file.filename.split(".").pop()}'
+        elif '.vagrant.' in result_file.filename:
+            extension = f'vagrant.{".".join(result_file.filename.split(".")[-2:])}'
         else:
             extension = result_file.filename.split('.').pop()
         if bundle_file_format_name:

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -59,7 +59,9 @@ import os
 # project
 from kiwi.tasks.base import CliTask
 from kiwi.help import Help
-from kiwi.system.result import Result
+from kiwi.system.result import (
+    Result, result_file_type
+)
 from kiwi.path import Path
 from kiwi.utils.compress import Compress
 from kiwi.utils.checksum import Checksum
@@ -161,29 +163,14 @@ class ResultBundleTask(CliTask):
             )
             del (ordered_results['bundle_format'])
 
+        # copy result files
+        origin_files = []
+        copied_files = []
         for result_file in list(ordered_results.values()):
             if result_file.use_for_bundle:
-                extension = result_file.filename.split('.').pop()
-                if bundle_file_format_name:
-                    bundle_file_basename = '.'.join(
-                        [bundle_file_format_name, extension]
-                    )
-                else:
-                    bundle_file_basename = os.path.basename(
-                        result_file.filename
-                    )
-                    # The bundle id is only taken into account for image results
-                    # which contains the image version appended in its file name
-                    part_name = list(bundle_file_basename.partition(image_name))
-                    bundle_file_basename = ''.join(
-                        [
-                            part_name[0], part_name[1],
-                            part_name[2].replace(
-                                image_version,
-                                image_version + '-' + self.command_args['--id']
-                            )
-                        ]
-                    )
+                bundle_file_basename = self._get_bundle_file_basename(
+                    result, result_file, bundle_file_format_name
+                )
                 log.info('Creating %s', bundle_file_basename)
                 bundle_file = ''.join(
                     [bundle_directory, '/', bundle_file_basename]
@@ -193,8 +180,45 @@ class ResultBundleTask(CliTask):
                         'cp', result_file.filename, bundle_file
                     ]
                 )
+                copied_files.append(bundle_file)
+                result_file_basename = os.path.basename(result_file.filename)
+                if result_file_basename != bundle_file_basename:
+                    symlink_orignal_name = f'{bundle_directory}/{result_file_basename}'
+                    if os.path.islink(symlink_orignal_name):
+                        os.unlink(symlink_orignal_name)
+                    os.symlink(bundle_file, symlink_orignal_name)
+                    origin_files.append(symlink_orignal_name)
+
+        # check and fix file references due to possible bundle_format renames
+        for origin_file in origin_files:
+            origin_file_basename = os.path.basename(origin_file)
+            bundle_file_basename = os.path.basename(os.readlink(origin_file))
+            log.info(f'Checking file references for {origin_file_basename}')
+            for result_file in copied_files:
+                if 'text' in Command.run(['file', result_file]).output:
+                    log.info(f'--> {result_file}')
+                    Command.run(
+                        [
+                            'sed', '-ie',
+                            f's/{origin_file_basename}/{bundle_file_basename}/g',
+                            result_file
+                        ]
+                    )
+                    os.unlink(f'{result_file}e')
+            os.unlink(origin_file)
+
+        # finalize result data, checksums, compressions
+        for result_file in list(ordered_results.values()):
+            if result_file.use_for_bundle:
+                bundle_file_basename = self._get_bundle_file_basename(
+                    result, result_file, bundle_file_format_name
+                )
+                log.info(f'Finalizing {bundle_file_basename}')
+                bundle_file = ''.join(
+                    [bundle_directory, '/', bundle_file_basename]
+                )
                 if result_file.compress:
-                    log.info('--> XZ compressing')
+                    log.info('--> Compressing')
                     compress = Compress(bundle_file)
                     compress.xz(self.runtime_config.get_xz_options())
                     bundle_file = compress.compressed_filename
@@ -233,6 +257,7 @@ class ResultBundleTask(CliTask):
                                 os.linesep
                             )
                         )
+
         if self.command_args['--package-as-rpm']:
             ResultBundleTask._build_rpm_package(
                 bundle_directory,
@@ -241,6 +266,35 @@ class ResultBundleTask(CliTask):
                 image_description.specification,
                 list(glob.iglob(f'{bundle_directory}/*'))
             )
+
+    def _get_bundle_file_basename(
+        self, result: Result, result_file: result_file_type,
+        bundle_file_format_name: str
+    ) -> str:
+        image_version = result.xml_state.get_image_version()
+        image_name = result.xml_state.xml_data.get_name()
+        extension = result_file.filename.split('.').pop()
+        if bundle_file_format_name:
+            bundle_file_basename = '.'.join(
+                [bundle_file_format_name, extension]
+            )
+        else:
+            bundle_file_basename = os.path.basename(
+                result_file.filename
+            )
+            # The bundle id is only taken into account for image results
+            # which contains the image version appended in its file name
+            part_name = list(bundle_file_basename.partition(image_name))
+            bundle_file_basename = ''.join(
+                [
+                    part_name[0], part_name[1],
+                    part_name[2].replace(
+                        image_version,
+                        image_version + '-' + self.command_args['--id']
+                    )
+                ]
+            )
+        return bundle_file_basename
 
     @staticmethod
     def _build_rpm_package(

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -273,7 +273,10 @@ class ResultBundleTask(CliTask):
     ) -> str:
         image_version = result.xml_state.get_image_version()
         image_name = result.xml_state.xml_data.get_name()
-        extension = result_file.filename.split('.').pop()
+        if '.tar.' in result_file.filename:
+            extension = f'tar.{result_file.filename.split(".").pop()}'
+        else:
+            extension = result_file.filename.split('.').pop()
         if bundle_file_format_name:
             bundle_file_basename = '.'.join(
                 [bundle_file_format_name, extension]

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -89,8 +89,13 @@ class TestResultBundleTask:
     @patch('kiwi.tasks.result_bundle.Compress')
     @patch('kiwi.tasks.result_bundle.Checksum')
     @patch('os.path.exists')
+    @patch('os.path.islink')
+    @patch('os.unlink')
+    @patch('os.symlink')
+    @patch('os.readlink')
     def test_process_result_bundle(
-        self, mock_exists, mock_checksum, mock_compress,
+        self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
+        mock_os_path_islink, mock_exists, mock_checksum, mock_compress,
         mock_path_which, mock_path_create, mock_command, mock_load
     ):
         # This file won't be copied with build id
@@ -111,6 +116,12 @@ class TestResultBundleTask:
         self.task.command_args['bundle'] = True
         self.task.command_args['--zsync-source'] = 'http://example.com/zsync'
 
+        command_result = Mock()
+        command_result.output = "some mime is text"
+        mock_command.return_value = command_result
+
+        mock_os_readlink.return_value = 'readlinked'
+
         m_open = mock_open()
         with patch('builtins.open', m_open, create=True):
             self.task.process()
@@ -125,14 +136,30 @@ class TestResultBundleTask:
                 os.sep.join([self.abs_bundle_dir, 'test-image-1.2.3-Build_42'])
             ]),
             call([
+                'cp', 'test-image-noversion',
+                os.sep.join([self.abs_bundle_dir, 'test-image-noversion'])
+            ]),
+            call([
+                'file',
+                os.sep.join([self.abs_bundle_dir, 'test-image-1.2.3-Build_42'])
+            ]),
+            call([
+                'sed', '-ie', 's/test-image-1.2.3/readlinked/g',
+                os.sep.join([self.abs_bundle_dir, 'test-image-1.2.3-Build_42'])
+            ]),
+            call([
+                'file',
+                os.sep.join([self.abs_bundle_dir, 'test-image-noversion'])
+            ]),
+            call([
+                'sed', '-ie', 's/test-image-1.2.3/readlinked/g',
+                os.sep.join([self.abs_bundle_dir, 'test-image-noversion'])
+            ]),
+            call([
                 'zsyncmake', '-e',
                 '-u', 'http://example.com/zsync/compressed_filename',
                 '-o', 'compressed_filename.zsync',
                 'compressed_filename'
-            ]),
-            call([
-                'cp', 'test-image-noversion',
-                os.sep.join([self.abs_bundle_dir, 'test-image-noversion'])
             ])
         ]
         mock_compress.assert_called_once_with(
@@ -160,8 +187,12 @@ class TestResultBundleTask:
     @patch('os.chdir')
     @patch('os.unlink')
     @patch('glob.iglob')
+    @patch('os.path.islink')
+    @patch('os.symlink')
+    @patch('os.readlink')
     def test_process_result_bundle_as_rpm(
-        self, mock_iglob, mock_unlink, mock_chdir, mock_exists, mock_checksum,
+        self, mock_os_readlink, mock_os_symlink, mock_os_path_islink,
+        mock_iglob, mock_unlink, mock_chdir, mock_exists, mock_checksum,
         mock_compress, mock_path_wipe, mock_path_which, mock_path_create,
         mock_command, mock_load, mock_Privileges_check_for_root_permissions
     ):
@@ -197,6 +228,14 @@ class TestResultBundleTask:
             ),
             call(
                 [
+                    'file',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'test-image-1.2.3-Build_42']
+                    )
+                ]
+            ),
+            call(
+                [
                     'rpmbuild', '--nodeps', '--nocheck', '--rmspec', '-bb',
                     os.sep.join([self.abs_bundle_dir, 'test-image.spec'])
                 ]
@@ -208,16 +247,20 @@ class TestResultBundleTask:
         mock_chdir.assert_called_once_with(
             self.abs_bundle_dir
         )
-        mock_unlink.assert_called_once_with(
-            os.sep.join([self.abs_bundle_dir, 'test-image-1.2.3-Build_42'])
-        )
+        assert mock_unlink.called
 
     @patch('kiwi.tasks.result_bundle.Result.load')
     @patch('kiwi.tasks.result_bundle.Command.run')
     @patch('kiwi.tasks.result_bundle.Path.create')
     @patch('os.path.exists')
+    @patch('os.path.islink')
+    @patch('os.unlink')
+    @patch('os.symlink')
+    @patch('os.readlink')
     def test_process_result_bundle_with_bundle_format(
-        self, mock_exists, mock_path_create, mock_command, mock_load
+        self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
+        mock_os_path_islink, mock_exists, mock_path_create, mock_command,
+        mock_load
     ):
         self.xml_state.profiles = None
         self.xml_state.host_architecture = 'x86_64'
@@ -242,22 +285,38 @@ class TestResultBundleTask:
 
         self.task.process()
 
-        mock_command.assert_called_once_with(
-            [
-                'cp',
-                '/tmp/mytest/Leap-15.2.x86_64-1.15.2.raw',
-                os.sep.join(
-                    [self.abs_bundle_dir, 'Leap-15.2-oem:1.raw']
-                )
-            ]
-        )
+        assert mock_command.call_args_list == [
+            call(
+                [
+                    'cp',
+                    '/tmp/mytest/Leap-15.2.x86_64-1.15.2.raw',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'Leap-15.2-oem:1.raw']
+                    )
+                ]
+            ),
+            call(
+                [
+                    'file',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'Leap-15.2-oem:1.raw']
+                    )
+                ]
+            )
+        ]
 
     @patch('kiwi.tasks.result_bundle.Result.load')
     @patch('kiwi.tasks.result_bundle.Command.run')
     @patch('kiwi.tasks.result_bundle.Path.create')
     @patch('os.path.exists')
+    @patch('os.path.islink')
+    @patch('os.unlink')
+    @patch('os.symlink')
+    @patch('os.readlink')
     def test_process_result_bundle_name_includes_version(
-        self, mock_exists, mock_path_create, mock_command, mock_load
+        self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
+        mock_os_path_islink, mock_exists, mock_path_create, mock_command,
+        mock_load
     ):
         result = Result(self.xml_state)
         result.add(
@@ -280,13 +339,22 @@ class TestResultBundleTask:
         )
         mock_path_create.assert_called_once_with(self.abs_bundle_dir)
         assert mock_command.call_args_list == [
-            call([
-                'cp', 'test-1.2.3-image-1.2.3',
-                os.sep.join([
-                    self.abs_bundle_dir,
-                    'test-1.2.3-image-1.2.3-Build_42'
-                ])
-            ])
+            call(
+                [
+                    'cp', 'test-1.2.3-image-1.2.3',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'test-1.2.3-image-1.2.3-Build_42']
+                    )
+                ]
+            ),
+            call(
+                [
+                    'file',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'test-1.2.3-image-1.2.3-Build_42']
+                    )
+                ]
+            )
         ]
 
     @patch('kiwi.tasks.result_bundle.Result.load')
@@ -296,8 +364,13 @@ class TestResultBundleTask:
     @patch('kiwi.tasks.result_bundle.Compress')
     @patch('kiwi.tasks.result_bundle.Checksum')
     @patch('os.path.exists')
+    @patch('os.path.islink')
+    @patch('os.unlink')
+    @patch('os.symlink')
+    @patch('os.readlink')
     def test_process_result_bundle_zsyncmake_missing(
-        self, mock_exists, mock_checksum, mock_compress,
+        self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
+        mock_os_path_islink, mock_exists, mock_checksum, mock_compress,
         mock_path_which, mock_path_create, mock_command, mock_load
     ):
         checksum = Mock()

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -313,6 +313,62 @@ class TestResultBundleTask:
     @patch('os.unlink')
     @patch('os.symlink')
     @patch('os.readlink')
+    def test_process_result_bundle_with_bundle_format_for_vagrant_types(
+        self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
+        mock_os_path_islink, mock_exists, mock_path_create, mock_command,
+        mock_load
+    ):
+        self.xml_state.profiles = None
+        self.xml_state.host_architecture = 'x86_64'
+        self.xml_state.get_build_type_name = Mock(
+            return_value='oem'
+        )
+        self.xml_state.xml_data.get_name = Mock(
+            return_value='Leap-15.2'
+        )
+
+        result = Result(self.xml_state)
+        result.add_bundle_format('%N-%T:%M')
+        result.add(
+            key='disk_image',
+            filename='/tmp/mytest/Leap-15.2.x86_64-1.15.2.vagrant.virtualbox.box',
+            use_for_bundle=True, compress=False, shasum=False
+        )
+
+        mock_exists.return_value = False
+        mock_load.return_value = result
+        self._init_command_args()
+
+        self.task.process()
+
+        assert mock_command.call_args_list == [
+            call(
+                [
+                    'cp',
+                    '/tmp/mytest/Leap-15.2.x86_64-1.15.2.vagrant.virtualbox.box',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'Leap-15.2-oem:1.vagrant.virtualbox.box']
+                    )
+                ]
+            ),
+            call(
+                [
+                    'file',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'Leap-15.2-oem:1.vagrant.virtualbox.box']
+                    )
+                ]
+            )
+        ]
+
+    @patch('kiwi.tasks.result_bundle.Result.load')
+    @patch('kiwi.tasks.result_bundle.Command.run')
+    @patch('kiwi.tasks.result_bundle.Path.create')
+    @patch('os.path.exists')
+    @patch('os.path.islink')
+    @patch('os.unlink')
+    @patch('os.symlink')
+    @patch('os.readlink')
     def test_process_result_bundle_with_bundle_format_for_archive_types(
         self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
         mock_os_path_islink, mock_exists, mock_path_create, mock_command,

--- a/test/unit/tasks/result_bundle_test.py
+++ b/test/unit/tasks/result_bundle_test.py
@@ -313,6 +313,62 @@ class TestResultBundleTask:
     @patch('os.unlink')
     @patch('os.symlink')
     @patch('os.readlink')
+    def test_process_result_bundle_with_bundle_format_for_archive_types(
+        self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
+        mock_os_path_islink, mock_exists, mock_path_create, mock_command,
+        mock_load
+    ):
+        self.xml_state.profiles = None
+        self.xml_state.host_architecture = 'x86_64'
+        self.xml_state.get_build_type_name = Mock(
+            return_value='oem'
+        )
+        self.xml_state.xml_data.get_name = Mock(
+            return_value='Leap-15.2'
+        )
+
+        result = Result(self.xml_state)
+        result.add_bundle_format('%N-%T:%M')
+        result.add(
+            key='disk_image',
+            filename='/tmp/mytest/Leap-15.2.x86_64-1.15.2.tar.xz',
+            use_for_bundle=True, compress=False, shasum=False
+        )
+
+        mock_exists.return_value = False
+        mock_load.return_value = result
+        self._init_command_args()
+
+        self.task.process()
+
+        assert mock_command.call_args_list == [
+            call(
+                [
+                    'cp',
+                    '/tmp/mytest/Leap-15.2.x86_64-1.15.2.tar.xz',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'Leap-15.2-oem:1.tar.xz']
+                    )
+                ]
+            ),
+            call(
+                [
+                    'file',
+                    os.sep.join(
+                        [self.abs_bundle_dir, 'Leap-15.2-oem:1.tar.xz']
+                    )
+                ]
+            )
+        ]
+
+    @patch('kiwi.tasks.result_bundle.Result.load')
+    @patch('kiwi.tasks.result_bundle.Command.run')
+    @patch('kiwi.tasks.result_bundle.Path.create')
+    @patch('os.path.exists')
+    @patch('os.path.islink')
+    @patch('os.unlink')
+    @patch('os.symlink')
+    @patch('os.readlink')
     def test_process_result_bundle_name_includes_version(
         self, mock_os_readlink, mock_os_symlink, mock_os_unlink,
         mock_os_path_islink, mock_exists, mock_path_create, mock_command,


### PR DESCRIPTION
When using a custom bundle_format the kiwi result bundler renames the output files to match the bundle_format. However, if there are output files that references other output files, for example the vmware binary (.vmdk) in the guest config file (.vmx) then this renaming breaks those result files. This patch adds a reference file check for all non binary output files if they contain a reference to another output file and updates the data accordingly.

This Fixes bsc#1221790