### PR TITLE
Backport eficsm bsc1243381

### DIFF
--- a/doc/source/image_description/elements.rst
+++ b/doc/source/image_description/elements.rst
@@ -384,6 +384,11 @@ bootpartsize="nonNegativeInteger":
   specifies the size in MB. If not set the boot partition
   size is set to 200 MB
 
+eficsm="true|false":
+  For images with an EFI layout, specify if the legacy
+  CSM (BIOS) mode should be supported or not. By default
+  CSM mode is enabled.
+
 efipartsize="nonNegativeInteger":
   For images with an EFI fat partition this attribute
   specifies the size in MB. If not set the EFI partition
@@ -447,13 +452,31 @@ editbootinstall="file_path":
 filesystem="btrfs|ext2|ext3|ext4|squashfs|xfs":
   The root filesystem
 
-firmware="efi|uefi":
-  Specifies the boot firmware of the appliance, supported
-  options are: `bios`, `ec2`, `efi`, `uefi`, `ofw` and `opal`.
-  This attribute is used to differentiate the image according to the
-  firmware which boots up the system. It mostly impacts the disk
-  layout and the partition table type. By default `bios` is used on x86,
+firmware="efi|uefi|bios|ec2|ofw|opal":
+  Specifies the boot firmware of the appliance. This attribute is
+  used to differentiate the image according to the firmware which
+  boots up the system. It mostly impacts the disk layout and the
+  partition table type. By default `bios` is used on x86,
   `ofw` on PowerPC and `efi` on ARM.
+
+  * `efi`
+    Standard EFI layout
+
+  * `uefi`
+    Standard EFI layout for secure boot
+
+  * `bios`
+    Standard BIOS layout for x86
+
+  * `ec2`
+    Standard BIOS layout for x86 using Xen grub modules for old
+    style Xen boot in Amazon EC2
+
+  * `ofw`
+    Standard PPC layout
+
+  * `opal`
+    Standard openPOWER PPC64 layout. kexec based boot process
 
 force_mbr="true|false":
   Boolean parameter to force the usage of a MBR partition

--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -84,7 +84,7 @@ function get_disk_list {
           disk_device="$(echo "${disk_mpath_child}" | cut -f1 -d:)"
         fi
         disk_size=$(echo "${disk_meta}" | cut -f2 -d:)
-        if [ ${max_disk} -gt 0 ]; then
+        if [ "${max_disk}" -gt 0 ]; then
             local disk_size_bytes
             disk_size_bytes=$(binsize_to_bytesize "${disk_size}") || \
                 disk_size_bytes=0

--- a/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
@@ -110,7 +110,7 @@ function probe_filesystem {
     if [ "${fstype}" = "crypto_LUKS" ];then
         fstype=luks
     fi
-    echo ${fstype}
+    echo "${fstype}"
 }
 
 #======================================

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -176,7 +176,7 @@ function create_dasd_partitions {
             echo >> ${partition_setup_file}
             continue
         fi
-        echo $cmd >> ${partition_setup_file}
+        echo "$cmd" >> ${partition_setup_file}
     done
     echo "w" >> ${partition_setup_file}
     echo "q" >> ${partition_setup_file}

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -62,6 +62,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
                 {'grub_directory_name': 'grub|grub2'}
         """
+        self.efi_csm = True if self.xml_state.build_type.get_eficsm() is None \
+            else self.xml_state.build_type.get_eficsm()
         self.custom_args = custom_args
         arch = Defaults.get_platform_name()
         if arch == 'x86_64':
@@ -573,7 +575,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
 
     def _supports_bios_modules(self):
-        if self.arch == 'ix86' or self.arch == 'x86_64' or Defaults.is_ppc64_arch(self.arch):
+        if self.efi_csm and (
+            self.arch == 'ix86' or self.arch == 'x86_64' or Defaults.is_ppc64_arch(self.arch)
+        ):
             return True
         return False
 

--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -124,6 +124,13 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
                 'No grub boot code installation on %s', self.arch
             )
             return False
+        elif self.firmware.efi_mode() and not self.firmware.legacy_bios_mode():
+            # In EFI mode without CSM, no install
+            # of grub2 boot code makes sense
+            log.info(
+                'No grub boot code installation in EFI only mode'
+            )
+            return False
         return True
 
     def install(self):

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -158,7 +158,8 @@ class InstallImageBuilder:
                 'volume_id': self.iso_volume_id,
                 'mbr_id': self.mbrid.get_id(),
                 'efi_mode': self.firmware.efi_mode(),
-                'ofw_mode': self.firmware.ofw_mode()
+                'ofw_mode': self.firmware.ofw_mode(),
+                'legacy_bios_mode': self.firmware.legacy_bios_mode()
             }
         }
 

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -133,7 +133,8 @@ class LiveImageBuilder:
                 'preparer': Defaults.get_preparer(),
                 'volume_id': self.volume_id,
                 'mbr_id': self.mbrid.get_id(),
-                'efi_mode': self.firmware.efi_mode()
+                'efi_mode': self.firmware.efi_mode(),
+                'legacy_bios_mode': self.firmware.legacy_bios_mode()
             }
         }
 

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1201,7 +1201,7 @@ class Defaults:
         :rtype: dict
         """
         return {
-            'x86_64': ['efi', 'uefi', 'bios', 'ec2hvm', 'ec2'],
+            'x86_64': ['efi', 'uefi', 'bios', 'ec2'],
             'i586': ['bios'],
             'i686': ['bios'],
             'ix86': ['bios'],

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -42,6 +42,8 @@ class FirmWare:
         self.firmware = xml_state.build_type.get_firmware()
         self.efipart_mbytes = xml_state.build_type.get_efipartsize()
         self.efi_partition_table = xml_state.build_type.get_efiparttable()
+        self.efi_csm = True if xml_state.build_type.get_eficsm() is None \
+            else xml_state.build_type.get_eficsm()
 
         if not self.firmware:
             self.firmware = Defaults.get_default_firmware(self.arch)
@@ -75,7 +77,7 @@ class FirmWare:
         else:
             return 'msdos'
 
-    def legacy_bios_mode(self):
+    def legacy_bios_mode(self) -> bool:
         """
         Check if the legacy boot from BIOS systems should be activated
 
@@ -84,14 +86,16 @@ class FirmWare:
         :rtype: bool
         """
         if self.get_partition_table_type() == 'gpt':
-            if self.arch == 'x86_64' or re.match('i.86', self.arch):
+            if (self.arch == 'x86_64' or re.match('i.86', self.arch)) and \
+               (self.firmware == 'efi' or self.firmware == 'uefi') and \
+               self.efi_csm:
                 return True
             else:
                 return False
         else:
             return False
 
-    def efi_mode(self):
+    def efi_mode(self) -> str:
         """
         Check if EFI mode is requested
 
@@ -101,6 +105,7 @@ class FirmWare:
         """
         if self.firmware in Defaults.get_efi_capable_firmware_names():
             return self.firmware
+        return ''
 
     def ec2_mode(self):
         """

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -19,7 +19,7 @@ import os
 import shutil
 import logging
 from typing import (
-    Dict, List
+    Dict, List, Union
 )
 
 # project
@@ -61,7 +61,7 @@ class IsoToolsBase:
         raise NotImplementedError
 
     def init_iso_creation_parameters(
-        self, custom_args: Dict[str, str] = None
+        self, custom_args: Dict[str, Union[str, bool]] = None
     ) -> None:
         """
         Create a set of standard parameters for the main isolinux loader

--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -17,7 +17,7 @@
 #
 import os
 from typing import (
-    Dict, List
+    Dict, List, Optional
 )
 
 # project
@@ -63,7 +63,7 @@ class IsoToolsXorrIso(IsoToolsBase):
         raise KiwiIsoToolError('xorriso tool not found')
 
     def init_iso_creation_parameters(
-        self, custom_args: Dict[str, str] = None
+        self, custom_args: Optional[Dict[str, str]] = None
     ) -> None:
         """
         Create a set of standard parameters

--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -17,7 +17,7 @@
 #
 import os
 from typing import (
-    Dict, List, Optional
+    Dict, List, Optional, Union
 )
 
 # project
@@ -63,33 +63,36 @@ class IsoToolsXorrIso(IsoToolsBase):
         raise KiwiIsoToolError('xorriso tool not found')
 
     def init_iso_creation_parameters(
-        self, custom_args: Optional[Dict[str, str]] = None
+        self, custom_args: Optional[Dict[str, Union[str, bool]]] = None
     ) -> None:
         """
         Create a set of standard parameters
 
         :param list custom_args: custom ISO meta data
         """
+        legacy_bios_mode = True
         efi_mode = False
         if custom_args:
             if custom_args.get('efi_mode'):
                 efi_mode = True
             if 'mbr_id' in custom_args:
                 self.iso_parameters += [
-                    '-application_id', custom_args['mbr_id']
+                    '-application_id', format(custom_args['mbr_id'])
                 ]
             if 'publisher' in custom_args:
                 self.iso_parameters += [
-                    '-publisher', custom_args['publisher']
+                    '-publisher', format(custom_args['publisher'])
                 ]
             if 'preparer' in custom_args:
                 self.iso_parameters += [
-                    '-preparer_id', custom_args['preparer']
+                    '-preparer_id', format(custom_args['preparer'])
                 ]
             if 'volume_id' in custom_args:
                 self.iso_parameters += [
-                    '-volid', custom_args['volume_id']
+                    '-volid', format(custom_args['volume_id'])
                 ]
+            if 'legacy_bios_mode' in custom_args:
+                legacy_bios_mode = bool(custom_args['legacy_bios_mode'])
         catalog_file = self.boot_path + '/boot.catalog'
         self.iso_parameters += [
             '-joliet', 'on', '-padding', '0'
@@ -99,7 +102,7 @@ class IsoToolsXorrIso(IsoToolsBase):
                 '-compliance', 'untranslated_names'
             ]
 
-        if Defaults.is_x86_arch(self.arch):
+        if Defaults.is_x86_arch(self.arch) and legacy_bios_mode:
             if efi_mode:
                 loader_file = os.sep.join(
                     [

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1501,6 +1501,15 @@ div {
             sch:param [ name = "attr" value = "efipartsize" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.eficsm.attribute =
+        ## For images with an EFI layout, specify if the legacy
+        ## CSM (BIOS) mode should be supported or not. By default
+        ## CSM mode is enabled
+        attribute eficsm { xsd:boolean }
+        >> sch:pattern [ id = "eficsm" is-a = "image_type"
+            sch:param [ name = "attr" value = "eficsm" ]
+            sch:param [ name = "types" value = "oem iso" ]
+        ]
     k.type.dosparttable_extended_layout.attribute =
         ## Specify to make use of logical partitions inside of an
         ## extended one. If set to true and if the msdos table type
@@ -2103,6 +2112,7 @@ div {
         k.type.bootpartsize.attribute? &
         k.type.efipartsize.attribute? &
         k.type.efiparttable.attribute? &
+        k.type.eficsm.attribute? &
         k.type.dosparttable_extended_layout.attribute? &
         k.type.bootprofile.attribute? &
         k.type.btrfs_quota_groups.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2161,6 +2161,18 @@ size is set to 200 MB</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.eficsm.attribute">
+      <attribute name="eficsm">
+        <a:documentation>For images with an EFI layout, specify if the legacy
+CSM (BIOS) mode should be supported or not. By default
+CSM mode is enabled</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="eficsm" is-a="image_type">
+        <sch:param name="attr" value="eficsm"/>
+        <sch:param name="types" value="oem iso"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.efipartsize.attribute">
       <attribute name="efipartsize">
         <a:documentation>For images with an EFI fat partition this attribute
@@ -3006,6 +3018,9 @@ kiwi-ng result bundle ...</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.efiparttable.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.eficsm.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.dosparttable_extended_layout.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2798,7 +2798,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootpartition=None, bootpartsize=None, efipartsize=None, eficsm=None, efiparttable=None, dosparttable_extended_layout=None, bootprofile=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, fscreateoptions=None, squashfscompression=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, metadata_path=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luks_version=None, luksOS=None, mdraid=None, overlayroot=None, overlayroot_write_partition=None, overlayroot_readonly_partsize=None, verity_blocks=None, embed_verity_metadata=None, standalone_integrity=None, embed_integrity_metadata=None, integrity_metadata_key_description=None, integrity_keyfile=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_fs_attributes=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, selinux_policy=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, ensure_empty_tmpdirs=None, xen_server=None, publisher=None, disk_start_sector=None, root_clone=None, boot_clone=None, bundle_format=None, bootloader=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, partitions=None, vagrantconfig=None, installmedia=None, luksformat=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2808,6 +2808,7 @@ class type_(GeneratedsSuper):
         self.bootpartsize = _cast(int, bootpartsize)
         self.efipartsize = _cast(int, efipartsize)
         self.efiparttable = _cast(None, efiparttable)
+        self.eficsm = _cast(bool, eficsm)
         self.dosparttable_extended_layout = _cast(bool, dosparttable_extended_layout)
         self.bootprofile = _cast(None, bootprofile)
         self.btrfs_quota_groups = _cast(bool, btrfs_quota_groups)
@@ -2993,6 +2994,8 @@ class type_(GeneratedsSuper):
     def set_efipartsize(self, efipartsize): self.efipartsize = efipartsize
     def get_efiparttable(self): return self.efiparttable
     def set_efiparttable(self, efiparttable): self.efiparttable = efiparttable
+    def get_eficsm(self): return self.eficsm
+    def set_eficsm(self, eficsm): self.eficsm = eficsm
     def get_dosparttable_extended_layout(self): return self.dosparttable_extended_layout
     def set_dosparttable_extended_layout(self, dosparttable_extended_layout): self.dosparttable_extended_layout = dosparttable_extended_layout
     def get_bootprofile(self): return self.bootprofile
@@ -3233,6 +3236,9 @@ class type_(GeneratedsSuper):
         if self.efiparttable is not None and 'efiparttable' not in already_processed:
             already_processed.add('efiparttable')
             outfile.write(' efiparttable=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.efiparttable), input_name='efiparttable')), ))
+        if self.eficsm is not None and 'eficsm' not in already_processed:
+            already_processed.add('eficsm')
+            outfile.write(' eficsm="%s"' % self.gds_format_boolean(self.eficsm, input_name='eficsm'))
         if self.dosparttable_extended_layout is not None and 'dosparttable_extended_layout' not in already_processed:
             already_processed.add('dosparttable_extended_layout')
             outfile.write(' dosparttable_extended_layout="%s"' % self.gds_format_boolean(self.dosparttable_extended_layout, input_name='dosparttable_extended_layout'))
@@ -3520,6 +3526,15 @@ class type_(GeneratedsSuper):
             already_processed.add('efiparttable')
             self.efiparttable = value
             self.efiparttable = ' '.join(self.efiparttable.split())
+        value = find_attr_value_('eficsm', node)
+        if value is not None and 'eficsm' not in already_processed:
+            already_processed.add('eficsm')
+            if value in ('true', '1'):
+                self.eficsm = True
+            elif value in ('false', '0'):
+                self.eficsm = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('dosparttable_extended_layout', node)
         if value is not None and 'dosparttable_extended_layout' not in already_processed:
             already_processed.add('dosparttable_extended_layout')

--- a/test/unit/bootloader/config/grub2_test.py
+++ b/test/unit/bootloader/config/grub2_test.py
@@ -78,7 +78,7 @@ class TestBootLoaderConfigGrub2:
             return_value=None
         )
         self.firmware.efi_mode = Mock(
-            return_value=None
+            return_value=''
         )
         mock_firmware.return_value = self.firmware
 
@@ -1335,7 +1335,7 @@ class TestBootLoaderConfigGrub2:
         Defaults.set_platform_name('x86_64')
         mock_get_boot_path.return_value = '/boot'
         self.firmware.efi_mode = Mock(
-            return_value=None
+            return_value=''
         )
         self.bootloader.xen_guest = True
         self.os_exists['root_dir/boot/grub2/fonts/unicode.pf2'] = False
@@ -1371,7 +1371,7 @@ class TestBootLoaderConfigGrub2:
         mock_get_boot_path.return_value = '/boot'
         self.bootloader.arch = 'ppc64le'
         self.firmware.efi_mode = Mock(
-            return_value=None
+            return_value=''
         )
         self.bootloader.xen_guest = False
         self.os_exists['root_dir/boot/grub2/fonts/unicode.pf2'] = False
@@ -1402,7 +1402,7 @@ class TestBootLoaderConfigGrub2:
         mock_get_boot_path.return_value = '/boot'
         self.bootloader.arch = 's390x'
         self.firmware.efi_mode = Mock(
-            return_value=None
+            return_value=''
         )
         self.bootloader.xen_guest = False
         self.os_exists['root_dir/boot/grub2/fonts/unicode.pf2'] = False

--- a/test/unit/bootloader/install/grub2_test.py
+++ b/test/unit/bootloader/install/grub2_test.py
@@ -136,6 +136,17 @@ class TestBootLoaderInstallGrub2:
         )
         assert self.bootloader.install_required() is False
 
+    def test_install_required_efi_no_csm(self):
+        self.bootloader.arch = 'x86_64'
+        self.bootloader.firmware = mock.Mock()
+        self.bootloader.firmware.efi_mode = mock.Mock(
+            return_value='efi'
+        )
+        self.bootloader.firmware.legacy_bios_mode = mock.Mock(
+            return_value=False
+        )
+        assert self.bootloader.install_required() is False
+
     def test_install_required_arm64(self):
         self.bootloader.arch = 'arm64'
         assert self.bootloader.install_required() is False

--- a/test/unit/builder/live_test.py
+++ b/test/unit/builder/live_test.py
@@ -17,6 +17,9 @@ class TestLiveImageBuilder:
         Defaults.set_platform_name('x86_64')
 
         self.firmware = Mock()
+        self.firmware.legacy_bios_mode = Mock(
+            return_value=True
+        )
         self.firmware.efi_mode = Mock(
             return_value='uefi'
         )
@@ -281,7 +284,8 @@ class TestLiveImageBuilder:
                     'volume_id': 'volid',
                     'efi_mode': 'uefi',
                     'efi_loader': 'kiwi-tmpfile',
-                    'udf': True
+                    'udf': True,
+                    'legacy_bios_mode': True
                 }
             },
             device_provider=mock_DeviceProvider.return_value,

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -87,7 +87,7 @@ class TestFirmWare:
         assert self.firmware_bios.ec2_mode() is None
 
     def test_efi_mode(self):
-        assert self.firmware_bios.efi_mode() is None
+        assert self.firmware_bios.efi_mode() == ''
         assert self.firmware_efi.efi_mode() == 'efi'
 
     def test_bios_mode(self):

--- a/test/unit/iso_tools/xorriso_test.py
+++ b/test/unit/iso_tools/xorriso_test.py
@@ -34,7 +34,8 @@ class TestIsoToolsXorrIso:
                 'mbr_id': 'app_id',
                 'publisher': 'org',
                 'preparer': 'preparer',
-                'volume_id': 'vol_id'
+                'volume_id': 'vol_id',
+                'legacy_bios_mode': True
             }
         )
         mock_which.assert_called_once_with(
@@ -99,7 +100,8 @@ class TestIsoToolsXorrIso:
                 'publisher': 'org',
                 'preparer': 'preparer',
                 'volume_id': 'vol_id',
-                'efi_mode': 'uefi'
+                'efi_mode': 'uefi',
+                'legacy_bios_mode': True
             }
         )
         assert self.iso_tool.iso_parameters == [

--- a/tox.ini
+++ b/tox.ini
@@ -224,8 +224,8 @@ commands =
     flake8 --statistics -j auto --count {toxinidir}/kiwi
     flake8 --statistics -j auto --count {toxinidir}/test/unit
     flake8 --statistics -j auto --count {toxinidir}/test/scripts
-    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117,SC2048 {toxinidir}/dracut/modules.d/*/*.sh -s bash'
-    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117,SC2048 {toxinidir}/kiwi/config/functions.sh -s bash'
+    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117,SC2048,SC2004 {toxinidir}/dracut/modules.d/*/*.sh -s bash'
+    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174,SC1117,SC2048,SC2004 {toxinidir}/kiwi/config/functions.sh -s bash'
 
 
 [testenv:scripts]


### PR DESCRIPTION
backport eficsm functionality, this PR backports the following commits

5ad114582367: Fix type hints of IsoToolXorrIso.init_iso_creation_parameters
8a6aed12ae40: Add new eficsm type attribute
dc713212f270: Evaluate eficsm everywhere
