### PR TITLE
Fix provides and obsoletes

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -429,6 +429,8 @@ Provides:       python%{python3_version_nodots}-kiwi = %{version}-%{release}
 Provides:       python%{python3_version}-kiwi = %{version}-%{release}
 %endif
 %endif
+Provides:       python3-kiwi = %{version}-%{release}
+Obsoletes:      python3-kiwi < %{version}-%{release}
 Obsoletes:      python2-kiwi
 Conflicts:      python2-kiwi
 Conflicts:      kiwi-man-pages < %{version}


### PR DESCRIPTION
When upgrading kiwi from a system that has still the old python3-kiwi but not the new python311-kiwi installed the upgrade fails because it tries to install one of the versioned sub-packages that exists only once from python311-kiwi and in a higher version. As such the install attempt becomes an unresolvable. The correct behavior would be that the install moves from python3-kiwi to python311-kiwi and its dependent sub-packages. This can be done by a correct provides and obsoletes information.